### PR TITLE
Don't commit new cache until the bundle operation is successful.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   "dependencies": {
     "debounce": "^1.0.0",
     "debug": "^2.1.0",
-    "mkdirp": "^0.5.1"
+    "mkdirp": "^0.5.1",
+    "xtend": "^4.0.0"
   },
   "devDependencies": {
     "standard": "^3.11.1"


### PR DESCRIPTION
This prevents syntax errors during bundling from resulting in an incomplete, corrupt dependency graph.
